### PR TITLE
Update blacklist.md

### DIFF
--- a/websearch/blacklist.md
+++ b/websearch/blacklist.md
@@ -20,6 +20,6 @@ https://iorate.github.io/ublacklist/subscriptions
 | 名称                                                                                                    | 链接                                                                                                   | 类型   |
 | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ---- |
 | [uBlacklist subscription compilation](https://github.com/eallion/uBlacklist-subscription-compilation) | https://git.io/ublacklist                                                                            | 中文   |
-| [uBlockOrigin-HUGE-AI-Blocklist](https://github.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist)         | https://raw.githubusercontent.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist/main/list\_uBlacklist.txt | AI生成 |
+| [uBlockOrigin-HUGE-AI-Blocklist](https://github.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist)         | https://raw.githubusercontent.com/laylavish/uBlockOrigin-HUGE-AI-Blocklist/main/list_uBlacklist.txt | AI生成 |
 
 <figure><img src="../.gitbook/assets/blacklist1.jpg" alt=""><figcaption><p>订阅源配置</p></figcaption></figure>


### PR DESCRIPTION
Although this is a one character change, it will help. I copy and pasted the url and it gave me a 404 error because of the backslash. Removing the backslash fixes the link.